### PR TITLE
Fixes: AddLiquidity Page

### DIFF
--- a/src/assets/images/blue-loader.svg
+++ b/src/assets/images/blue-loader.svg
@@ -1,3 +1,0 @@
-<svg width="94" height="94" viewBox="0 0 94 94" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M92 47C92 22.1472 71.8528 2 47 2C22.1472 2 2 22.1472 2 47C2 71.8528 22.1472 92 47 92" stroke="#2172E5" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/src/assets/images/yellow-loader.svg
+++ b/src/assets/images/yellow-loader.svg
@@ -1,0 +1,3 @@
+<svg width="94" height="94" viewBox="0 0 94 94" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M92 47C92 22.1472 71.8528 2 47 2C22.1472 2 2 22.1472 2 47C2 71.8528 22.1472 92 47 92" stroke="#F6F37C" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/SearchModal/CommonBases.tsx
+++ b/src/components/SearchModal/CommonBases.tsx
@@ -53,7 +53,7 @@ export default function CommonBases({
         >
           <CurrencyLogo currency={ETHER} style={{ marginRight: 8 }} />
           <Text fontWeight={500} fontSize={16}>
-            ETH
+            FUSE
           </Text>
         </BaseWrapper>
         {(chainId ? SUGGESTED_BASES[chainId] : []).map((token: Token) => {

--- a/src/components/TransactionConfirmationModal/index.tsx
+++ b/src/components/TransactionConfirmationModal/index.tsx
@@ -9,7 +9,7 @@ import { RowBetween } from '../Row'
 import { AlertTriangle, ArrowUpCircle } from 'react-feather'
 import { ButtonPrimary } from '../Button'
 import { AutoColumn, ColumnCenter } from '../Column'
-import Circle from '../../assets/images/blue-loader.svg'
+import Circle from '../../assets/images/yellow-loader.svg'
 
 import { getExplorerLink, getExplorerLinkText } from '../../utils'
 import { useActiveWeb3React } from '../../hooks'

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -90,13 +90,15 @@ export const CUSTOM_BASES: { [chainId in ChainId]?: { [tokenAddress: string]: To
 // used for display in the default list when adding liquidity
 export const SUGGESTED_BASES: ChainTokenList = {
   ...WETH_ONLY,
-  [ChainId.MAINNET]: [...WETH_ONLY[ChainId.MAINNET], DAI, USDC, USDT]
+  [ChainId.MAINNET]: [...WETH_ONLY[ChainId.MAINNET], DAI, USDC, USDT],
+  [ChainId.FUSE]: [...WETH_ONLY[ChainId.FUSE], FUSE_DAI, FUSE_USDC, FUSE_USDT, FUSE_WBTC, FUSE_WETH]
 }
 
 // used to construct the list of all pairs we consider by default in the frontend
 export const BASES_TO_TRACK_LIQUIDITY_FOR: ChainTokenList = {
   ...WETH_ONLY,
-  [ChainId.MAINNET]: [...WETH_ONLY[ChainId.MAINNET], DAI, USDC, USDT]
+  [ChainId.MAINNET]: [...WETH_ONLY[ChainId.MAINNET], DAI, USDC, USDT],
+  [ChainId.FUSE]: [...WETH_ONLY[ChainId.FUSE], FUSE_DAI, FUSE_USDC, FUSE_USDT, FUSE_WBTC, FUSE_WETH]
 }
 
 export const PINNED_PAIRS: { readonly [chainId in ChainId]?: [Token, Token][] } = {
@@ -107,6 +109,10 @@ export const PINNED_PAIRS: { readonly [chainId in ChainId]?: [Token, Token][] } 
     ],
     [USDC, USDT],
     [DAI, USDT]
+  ],
+  [ChainId.FUSE]: [
+    [FUSE_USDC, FUSE_USDT],
+    [FUSE_DAI, FUSE_USDT]
   ]
 }
 


### PR DESCRIPTION
PR Notes:
- [x] Fix gasEstimate on addLiquidty page, now dynamically estimates instead of using a constant
- [x] Added DAI, USDC, USDT, WBTC, WETH to the `BASES_TO_TRACK_LIQUIDITY_FOR` constant to enable liquidity tracking against those with those tokens
- [x] Added DAI, USDC, USDT, WBTC, WETH to the `SUGGESTED_BASES`, constant to show suggestions to the user about tokens most commonly paired when choosing a token under addLiquidity
- [x] Change color of confirmation dialog spinner
- [x] Change native currency name from ETH TO FUSE under `CommonBases.tsx`
